### PR TITLE
Add operation via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 This module adds a robots metatag to discourage well-behaved search engine spiders from crawling and indexing your site.
 
+###### Installation
+Install via composer:  `composer require nobrainerweb/silverstripe-robots-noindex`
+
+Don't forget to run a `dev/build?flush`
+
+
+
 The module will automatically add the tag when your site is in dev or test mode.  It can also be activated regardless of the site mode with the addition of an environment variable called 'SEO_PREVENT_INDEXING' which can be set to true.
 
 For example, if you are using a .env file, you would add the following line to enable the module:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-Block site from being indexed when site is en dev or test mode.
+Block site from being indexed when site is in dev or test mode, or when an environment variable is set.
+
 Shows a warning in the CMS. 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-Block site from being indexed when site is in dev or test mode, or when an environment variable is set.
+This module adds a robots metatag to discourage well-behaved search engine spiders from crawling and indexing your site.
 
-Shows a warning in the CMS. 
+The module will automatically add the tag when your site is in dev or test mode.  It can also be activated regardless of the site mode with the addition of an environment variable called 'SEO_PREVENT_INDEXING' which can be set to true.
+
+For example, if you are using a .env file, you would add the following line to enable the module:
+
+`SEO_PREVENT_INDEXING = true` 
+
+A warning is shown in the CMS when the module is active and indexing is discouraged.
+
+ 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,3 +1,7 @@
 en:
   NobrainerWeb\NoIndex\NoIndexExtension:
-    NO_INDEX_WARNING: 'Warning: No indexing! This website is running in development mode, and is not being indexed by search engines'
+    NO_INDEX_WARNING: 'Warning: No indexing!'
+    NO_INDEX_WARNING_DEV: 'This website is running in development mode, and is not being indexed by search engines'
+    NO_INDEX_WARNING_TEST: 'This website is running in test mode, and is not being indexed by search engines'
+    NO_INDEX_WARNING_ENV: 'Search engine indexing is disabled by an environment setting'
+

--- a/src/NoIndexExtension.php
+++ b/src/NoIndexExtension.php
@@ -3,6 +3,7 @@
 namespace NobrainerWeb\NoIndex;
 
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\LiteralField;
 
@@ -11,7 +12,7 @@ class NoIndexExtension extends Extension
 
     public function MetaTags(&$tags)
     {
-        if (Director::isDev() || Director::isTest()) {
+        if (Director::isDev() || Director::isTest() || (Environment::getEnv('SEO_PREVENT_INDEXING') === true)) {
             $tags .= '<meta name="robots" content="noindex, nofollow" />';
         }
 


### PR DESCRIPTION
Hi,

I've added a little functionality to allow the module to be enabled via an environment variable, since we often run UAT environments in live mode, but still want them to contain the robots directive.

I've also split out the warning message generation so the module can give the user the reason the site isn't being indexed.

All the best